### PR TITLE
Update to v1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.deepl
+.dictionary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Added [B]reak option to ExtendedStringConfirmation
  - Added progress indicator; files without changes are not reported to the console
  - Fixed bug when saving DeepL credentials; .deepl folder created if not exists
+ - Fixed bug when saving dictionary; .dictionary folder created if not exists
  - Added .gitignore with /.deepl and /.dictionary folders
  - Other minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### v1.2 (29.09.2023)
+ - Added [B]reak option to ExtendedStringConfirmation
+
+
 ### v1.1 (06.09.2023)
  - Adding Manifest to give more information about the module
  - Importing depenency module Microsoft.Dynamics.Nav.Model.Tools directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Added [B]reak option to ExtendedStringConfirmation
  - Added progress indicator; files without changes are not reported to the console
  - Fixed bug when saving DeepL credentials; .deepl folder created if not exists
+ - Added .gitignore with /.deepl and /.dictionary folders
  - Other minor changes
 
 ### v1.1 (06.09.2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v1.2 (29.09.2023)
  - Dictionary is now alfabetically sorted using [System.Collections.Specialized.OrderedDictionary]
  - Added [B]reak option to ExtendedStringConfirmation
+ - Added progress indicator; files without changes are not reported to the console
  - Other minor changes
 
 ### v1.1 (06.09.2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ### v1.2 (29.09.2023)
+ - Dictionary is now alfabetically sorted using [System.Collections.Specialized.OrderedDictionary]
  - Added [B]reak option to ExtendedStringConfirmation
  - Other minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Dictionary is now alfabetically sorted using [System.Collections.Specialized.OrderedDictionary]
  - Added [B]reak option to ExtendedStringConfirmation
  - Added progress indicator; files without changes are not reported to the console
+ - Fixed bug when saving DeepL credentials; .deepl folder created if not exists
  - Other minor changes
 
 ### v1.1 (06.09.2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v1.2 (29.09.2023)
  - Added [B]reak option to ExtendedStringConfirmation
-
+ - Other minor changes
 
 ### v1.1 (06.09.2023)
  - Adding Manifest to give more information about the module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ### v1.2 (29.09.2023)
+ - Dictionary has now higher priority than DevelopmentLanguageId
  - Dictionary is now alfabetically sorted using [System.Collections.Specialized.OrderedDictionary]
  - Added [B]reak option to ExtendedStringConfirmation
  - Added progress indicator; files without changes are not reported to the console

--- a/NavTranslator.psd1
+++ b/NavTranslator.psd1
@@ -12,7 +12,7 @@
 RootModule = 'NavTranslator.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1'
+ModuleVersion = '1.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -30,7 +30,7 @@ CompanyName = 'Statista GmbH'
 Copyright = 'Vladimir Kozlov (c) 2023'
 
 # Description of the functionality provided by this module
-Description = 'Dynamics NAV Objects Language Translator'
+Description = 'Automated Dynamics NAV objects language translator'
 
 # Minimum version of the PowerShell engine required by this module
 PowerShellVersion = '7.0'

--- a/NavTranslator.psm1
+++ b/NavTranslator.psm1
@@ -496,6 +496,9 @@ function Save-Dictionary {
     )
 
     if ($LanguageSetup.DictionaryLines -ne $Dict.Count) {
+        if (!(Test-Path -Path $LanguageSetup.DictionatyPath -PathType Container)) {
+            New-Item -Path $LanguageSetup.DictionatyPath -ItemType Directory -Force | Out-Null
+        }
         $Dict.GetEnumerator() | Select-Object Key, Value | Sort-Object -Property 'Key' | Export-Csv -Path $LanguageSetup.DictionatyPath -Encoding utf8 -Force
         Write-Host "Dictionary has been updated by $($Dict.Count - $LanguageSetup.DictionaryLines) new lines" -ForegroundColor Cyan
     } else {

--- a/NavTranslator.psm1
+++ b/NavTranslator.psm1
@@ -591,7 +591,7 @@ function Get-ExtendedStringConfirmation {
         [string] $LanguageName
     )
     while (!$Confirmed) {
-        Write-Host "Select: [A]ccept / [K]eep original / [E]dit / [C]apitalize? " -NoNewline
+        Write-Host "Select: [A]ccept / [K]eep original / [E]dit / [C]apitalize / [B]reak? " -NoNewline
         $Readkey = [console]::ReadKey()
 
         switch ($Readkey.Key) {
@@ -624,6 +624,9 @@ function Get-ExtendedStringConfirmation {
                 Show-StringWithComment -LanguageName $LanguageName -String $Result -Comment ''
                 $Confirmed = Get-UserConfirmation
                 break
+            }
+            "B" {
+                throw ""
             }
             default {
                 $Result = ''

--- a/NavTranslator.psm1
+++ b/NavTranslator.psm1
@@ -12,9 +12,10 @@ $Error.clear()
         -BaseLanguageId, as a language id which will be used for making translations from.
         -WorkLanguageId, as a language id which will be checked and updated.
 
-    Every LanguageId used is the integer number representing Windows Language Code.
+    Every LanguageId is an integer number representing Windows Language Code.
     See more here: https://www.venea.net/web/culture_code
-    To get your available languages, run:
+
+    To get your available languages, run in PowerShell (at least v6.2):
     Get-Culture -ListAvailable | select LCID,Name,DisplayName,ThreeLetterWindowsLanguageName,ThreeLetterISOLanguageName,TwoLetterISOLanguageName | Out-GridView
 
     The script will find all the Dynamics NAV TXT format objects recursively within the Path. Every
@@ -33,7 +34,7 @@ $Error.clear()
     ".\.dictionary\" folder. The dictionary is created automatically when it is not found. The dictionary
     will be filled with all confirmed translations and saved to the same path. During translation process,
     the dictionary will be checked for existing translations.
-    Existing dictionaries will be reused for all the next translations with the same language settings.
+    Existing dictionaries will be reused for all translations with the same language settings.
 
     DeepL
     DeepL is a translation web service which provides a free REST API. See more: https://www.deepl.com/pro-api
@@ -60,7 +61,7 @@ $Error.clear()
         - The script will find all the objects recursively and will help automate translation process.
         - Files within the Path will be updated.
         - Translations dictionary will be created in ".\.dictionary\ENU_DEU.csv"
-        - Dictionary will be automatically reused for any further translations given the same Base and Missing language ids.
+        - Dictionary will be automatically reused for any further translations given the same Base and Work language ids.
         - DeepL API key will be created under ".\.deepl\apikey.xml"
 
 .PARAMETER Path
@@ -633,6 +634,7 @@ function Get-ExtendedStringConfirmation {
             }
         }
     }
+    Write-Host
     return $Result
 }
 

--- a/NavTranslator.psm1
+++ b/NavTranslator.psm1
@@ -155,7 +155,7 @@ function Update-TranslationLine {
         [pscustomobject] $TranslationFiles,
 
         [Parameter(mandatory = $true)]
-        [hashtable] $Dict
+        [System.Collections.Specialized.OrderedDictionary] $Dict
     )
     $Pattern = Get-SubstringByPattern -Line $Line -WorkLanguageId $LanguageSetup.WorkLanguageId
     $BaseLanguageString = Read-LanguageString -LanguageFile $TranslationFiles.BaseLanguageFile -Pattern $Pattern
@@ -457,7 +457,7 @@ function Get-Dictionary {
         [pscustomobject] $LanguageSetup
     )
 
-    $Dict = @{}
+    $Dict = [ordered]@{}
     if (Test-Path -Path $LanguageSetup.DictionatyPath -PathType Leaf) {
         Import-Csv -Path $LanguageSetup.DictionatyPath | ForEach-Object { $Dict.Add($_.Key, $_.Value) }
         Write-Host "Dictionary " -NoNewline -ForegroundColor Cyan
@@ -479,11 +479,11 @@ function Save-Dictionary {
         [pscustomobject] $LanguageSetup,
 
         [Parameter(mandatory = $true)]
-        [hashtable] $Dict
+        [System.Collections.Specialized.OrderedDictionary] $Dict
     )
 
     if ($LanguageSetup.DictionaryLines -ne $Dict.Count) {
-        $Dict.GetEnumerator() | Select-Object Key, Value | Export-Csv -Path $LanguageSetup.DictionatyPath -Encoding utf8 -Force
+        $Dict.GetEnumerator() | Select-Object Key, Value | Sort-Object -Property 'Key' | Export-Csv -Path $LanguageSetup.DictionatyPath -Encoding utf8 -Force
         Write-Host "Dictionary has been updated by $($Dict.Count - $LanguageSetup.DictionaryLines) new lines" -ForegroundColor Cyan
     } else {
         Write-Host "Dictionary has not been changed" -ForegroundColor DarkGray

--- a/NavTranslator.psm1
+++ b/NavTranslator.psm1
@@ -531,6 +531,9 @@ function Initialize-DeeplCredentials {
     if (Test-Path -Path "$PSScriptRoot\.deepl\ApiKey.xml" -PathType Leaf) {
         Write-Host "DeepL API key found" -ForegroundColor DarkGray
     } else {
+        if (!(Test-Path -Path "$PSScriptRoot\.deepl" -PathType Container)) {
+            New-Item -Path "$PSScriptRoot\.deepl" -ItemType Directory | Out-Null
+        }
         Write-Host "DeepL API key not found" -ForegroundColor Yellow
         $DeeplCred = Get-Credential -Message "Enter DeepL API key (without DeepL-Auth-Key prefix)" -UserName 'DeepL'
         $DeeplCred | Export-Clixml -Path "$PSScriptRoot\.deepl\ApiKey.xml" -Force


### PR DESCRIPTION
 - Dictionary has now higher priority than DevelopmentLanguageId
 - Dictionary is now alfabetically sorted using [System.Collections.Specialized.OrderedDictionary]
 - Added [B]reak option to ExtendedStringConfirmation
 - Added progress indicator; files without changes are not reported to the console
 - Fixed bug when saving DeepL credentials; .deepl folder created if not exists
 - Fixed bug when saving dictionary; .dictionary folder created if not exists
 - Added .gitignore with /.deepl and /.dictionary folders
 - Other minor changes